### PR TITLE
Added missing Clone derive

### DIFF
--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -940,7 +940,7 @@ impl ConfirmedTransactionWithStatusMeta {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EncodedConfirmedTransactionWithStatusMeta {
     pub slot: Slot,


### PR DESCRIPTION
#### Problem

Derive macro on `EncodedConfirmedTransactionWithStatusMeta` missing `Clone`.

#### Summary of Changes

added `Clone` to derive macro

