### PR TITLE
SF-2708 Filter out token program

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6197,9 +6197,9 @@ impl Bank {
         account.lamports()
     }
 
-    pub fn read_data(account: &AccountSharedData) -> Option<Vec<u8>> {
+    pub fn read_data(pubkey: &Pubkey, account: &AccountSharedData) -> Option<Vec<u8>> {
         let data = account.data();
-        if data.len() > STEP_TX_DATUM_MAX_SIZE || account.executable() {
+        if data.len() > STEP_TX_DATUM_MAX_SIZE || account.executable() || pubkey == token_program {
             None
         } else {
             Some(data.to_vec())
@@ -6217,7 +6217,7 @@ impl Bank {
             .map(|x| {
                 (
                     Self::read_balance(&x),
-                    Self::read_data(&x),
+                    Self::read_data(pubkey, &x),
                 )
             })
             .unwrap_or((0, None))


### PR DESCRIPTION
### Status

Draft, not sure we need to worry

#### Problem

The Step Finance changes which pushed acct data to geyser along with tx messages include token accounts, which is not necessary given that token accounts are already parsed and meta provided about them.

This bloats the message and is perhaps not needed.

#### Summary of Changes

Filters out token accounts from geyser messages
