### PR TITLE
invert mint logic

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6056,8 +6056,8 @@ impl Bank {
         if data.len() > STEP_TX_DATUM_MAX_SIZE 
             //executable accounts
             || account.executable() 
-            //exclude token MINT accounts
-            || (self.dataum_excluded_programs.0.contains(owner) && data.len() == 82)
+            //exclude token program NON MINT accounts
+            || (self.dataum_excluded_programs.0.contains(owner) && data.len() != 82)
             //exclude by owner
             || self.dataum_excluded_programs.1.contains(owner)
             //exclude by key


### PR DESCRIPTION
#### Problem
Dana was a dick and didn't test properly and logic is reversed - we're sending token program account data EXCEPT for mints.  We want to send ONLY mints. He even got the comment wrong, as if this was malicious on purpose.

#### Summary of Changes
Changed logic to exclude only NON mint accounts
